### PR TITLE
fix: Use the same prefix for all Dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: 'feat'
-      prefix-development: 'build'
+      prefix: 'build'
       include: 'scope'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Based on https://github.com/linz/ept-aws-infrastructure/commit/139415117a55db2dcac6aabd7a7388cf26cab8ef