### PR TITLE
feat: Pin actions to hashes TDE-934

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,4 +7,4 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: linz/action-typescript@v3
+      - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
         id: release
         with:
           release-type: node
@@ -22,7 +22,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - name: Build and test
-        uses: linz/action-typescript@v3
+        uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
           registry-url: 'https://npm.pkg.github.com'
 


### PR DESCRIPTION
Done with pin-github-action <https://github.com/mheap/pin-github-action> 1.8.0 using `npx pin-github-action .github/workflows/*.yml`.

Dependabot should support updating in the same fashion <https://github.com/dependabot/dependabot-core/issues/8277#issuecomment-1782819752>.

Had to `export GH_ADMIN_TOKEN=github_pat_…` using a fine-grained personal access tokens with no extra access to work around rate limiting *and* to be able to work in private repos
<https://github.com/mheap/pin-github-action/issues/73>.